### PR TITLE
(WIP) When the ServiceMatrix license has expired and user opens an existing solution, the canvas will be disabled.

### DIFF
--- a/src/ServiceMatrix.Automation/Diagramming/Converters/InverseBooleanConverter.cs
+++ b/src/ServiceMatrix.Automation/Diagramming/Converters/InverseBooleanConverter.cs
@@ -1,0 +1,28 @@
+﻿namespace NServiceBusStudio.Automation.Diagramming.Converters
+{
+    using System;
+    using System.Windows.Data;
+
+    [ValueConversion(typeof(bool), typeof(bool))]
+    public class InverseBooleanConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter,
+            System.Globalization.CultureInfo culture)
+        {
+            if (targetType != typeof(bool))
+                throw new InvalidOperationException("The target must be a boolean");
+
+            return !(bool)value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter,
+            System.Globalization.CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+        #endregion
+    }
+}

--- a/src/ServiceMatrix.Automation/Diagramming/ViewModels/ServiceMatrixDiagramViewModel.cs
+++ b/src/ServiceMatrix.Automation/Diagramming/ViewModels/ServiceMatrixDiagramViewModel.cs
@@ -10,15 +10,20 @@ using System.Windows;
 
 namespace ServiceMatrix.Diagramming.ViewModels
 {
+    using NServiceBusStudio.Automation.Model;
+
     public class ServiceMatrixDiagramViewModel : INotifyPropertyChanged
     {
         public ServiceMatrixDiagramAdapter Adapter { get; set; }
         public ServiceMatrixDiagramMindscapeViewModel Diagram { get; set; }
 
+        public bool IsServiceMatrixLicenseExpired { get; set; }
+
         public ServiceMatrixDiagramViewModel(ServiceMatrixDiagramAdapter adapter)
         {
             this.Adapter = adapter;
             this.Diagram = adapter.ViewModel;
+            IsServiceMatrixLicenseExpired = !GlobalSettings.Instance.IsLicenseValid ;
 
             this.OnShowAddEndpoint = new RelayCommand(() => {
                 var window = new AddEndpoint();

--- a/src/ServiceMatrix.Automation/Diagramming/Views/Diagram.xaml
+++ b/src/ServiceMatrix.Automation/Diagramming/Views/Diagram.xaml
@@ -7,8 +7,11 @@
              xmlns:vsfx="clr-namespace:NuPattern.Presentation.VsIde;assembly=NuPattern.Presentation"
              xmlns:ms="http://namespaces.mindscape.co.nz/wpf"
              xmlns:styles="clr-namespace:ServiceMatrix.Diagramming.Styles"
+             xmlns:model="clr-namespace:NServiceBusStudio.Automation.Model"
+             xmlns:converters="clr-namespace:NServiceBusStudio.Automation.Diagramming.Converters"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="600">
+    
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -25,6 +28,7 @@
         
         <Grid.Resources>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+            <converters:InverseBooleanConverter x:Key="InverseBooleanConverter" />
         </Grid.Resources>
         
         <!-- Toolbar -->
@@ -43,7 +47,7 @@
                     </Style>
                 </StackPanel.Resources>
 
-                <Button Command="{Binding OnShowAddEndpoint}">
+                <Button Command="{Binding OnShowAddEndpoint}" IsEnabled="{Binding Path=IsServiceMatrixLicenseExpired, Converter={StaticResource InverseBooleanConverter}}">
                     <StackPanel Orientation="Horizontal">
                         <Image Source="../Styles/Images/BlueEndpointIcon.png" Width="23"></Image>
                         <TextBlock Margin="5,0,0,0" VerticalAlignment="Center">New endpoint</TextBlock>
@@ -53,12 +57,16 @@
                 <Border Width="1" Background="#B1B1B1" Margin="0, 5, 0, 5"></Border>
                 <Border Width="2" Background="#FFFFFF" Margin="0, 5, 0, 5"></Border>
 
-                <Button Command="{Binding OnShowAddService}">
+                <Button Command="{Binding OnShowAddService}" IsEnabled="{Binding Path=IsServiceMatrixLicenseExpired, Converter={StaticResource InverseBooleanConverter}}">
                     <StackPanel Orientation="Horizontal">
                         <Image Source="../Styles/Images/BlueServiceIcon.png" Width="23"></Image>
                         <TextBlock Margin="5,0,0,0" VerticalAlignment="Center">New service</TextBlock>
                     </StackPanel>
                 </Button>
+
+                <TextBlock Visibility="{Binding IsServiceMatrixLicenseExpired, Converter={StaticResource BooleanToVisibility}}">
+                    The canvas has been disabled as the license has expired
+                </TextBlock>
             </StackPanel>
         </Grid>
 
@@ -66,7 +74,7 @@
 
         <ms:DiagramSurface Grid.Row="1"
                            x:Name="ds"
-                           Diagram="{Binding Diagram}"
+                           Diagram="{Binding Diagram}" IsEnabled="{Binding Path=IsServiceMatrixLicenseExpired, Converter={StaticResource InverseBooleanConverter}}"
                            Formatter="{StaticResource Formatter}" 
                            ZoomMode="MouseWheel"
                            IsSmartScrollingEnabled="True"
@@ -103,14 +111,14 @@
         
         <!-- Empty state buttons -->
 
-        <Grid x:Name="EmptyStateButtons" Grid.RowSpan="2" Visibility="Visible">
+        <Grid x:Name="EmptyStateButtons" Grid.RowSpan="2" Visibility="Visible"> 
             
             <StackPanel VerticalAlignment="Center"
                         HorizontalAlignment="Center"
                         Orientation="Horizontal">
                 
                 <Button BorderThickness="0"
-                        Command="{Binding OnShowAddEndpoint}"
+                        Command="{Binding OnShowAddEndpoint}" 
                         Cursor="Hand">
                     <Button.Template>
                         <ControlTemplate TargetType="{x:Type Button}">

--- a/src/ServiceMatrix.Automation/Model/Application.cs
+++ b/src/ServiceMatrix.Automation/Model/Application.cs
@@ -20,6 +20,8 @@ using System.Diagnostics;
 
 namespace NServiceBusStudio
 {
+    using Automation.Model;
+
     partial interface IApplication
     {
         string ContractsProjectName { get; }
@@ -292,9 +294,12 @@ namespace NServiceBusStudio
                 LicensedVersion = LicenseManager.Instance.PromptUserForLicenseIfTrialHasExpired();
                 if (LicensedVersion)
                 {
+                    GlobalSettings.Instance.IsLicenseValid = true;
                     EnableSolutionBuilder();
                     return;
                 }
+
+                GlobalSettings.Instance.IsLicenseValid = false;
                 DisableSolutionBuilder();
                 if (!AsProduct().IsSerializing) // is creating
                 {
@@ -304,6 +309,7 @@ namespace NServiceBusStudio
             }
             else
             {
+                GlobalSettings.Instance.IsLicenseValid = true;
                 EnableSolutionBuilder();
             }
         }
@@ -319,11 +325,6 @@ namespace NServiceBusStudio
             this.IsValidLicensed = false;
             this.CustomSolutionBuilder.DisableSolutionBuilder();
         }
-
-
-
-
-
 
 
         public InfrastructureManager InfrastructureManager { get; private set; }

--- a/src/ServiceMatrix.Automation/Model/GlobalSettings.cs
+++ b/src/ServiceMatrix.Automation/Model/GlobalSettings.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBusStudio.Automation.Model
+{
+    public class GlobalSettings 
+    {
+        static GlobalSettings instance = new GlobalSettings();
+        bool isLicenseValid = true;
+
+        public GlobalSettings()
+        {
+        }
+
+        public bool IsLicenseValid
+        {
+            get { return isLicenseValid; }
+            set
+            {
+                isLicenseValid = value;
+            }
+        }
+
+        public static GlobalSettings Instance
+        {
+            get
+            {
+                return instance;
+            }   
+        }
+    }
+}

--- a/src/ServiceMatrix.Automation/ServiceMatrix.Automation.csproj
+++ b/src/ServiceMatrix.Automation/ServiceMatrix.Automation.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Conditions\IsSagaComponentCondition.cs" />
     <Compile Include="Conditions\IsComponentCommandProcessorCondition.cs" />
     <Compile Include="Conditions\IsProcessorComponentCondition.cs" />
+    <Compile Include="Diagramming\Converters\InverseBooleanConverter.cs" />
     <Compile Include="Diagramming\ViewModels\Connections\MessageConnection.cs" />
     <Compile Include="Diagramming\ViewModels\Shapes\MessageNode.cs" />
     <Compile Include="Dialog\SagaStarterPicker.xaml.cs">
@@ -214,6 +215,7 @@
     <Compile Include="Licensing\NonLockingFileReader.cs" />
     <Compile Include="Licensing\StaThreadRunner.cs" />
     <Compile Include="Licensing\UserSidChecker.cs" />
+    <Compile Include="Model\GlobalSettings.cs" />
     <Compile Include="ProcessedCommandLinkReply.cs" />
     <Compile Include="ProcessedCommandLinkReply.Design.cs">
       <DependentUpon>ProcessedCommandLinkReply.cs</DependentUpon>


### PR DESCRIPTION
Relates to #280 

@esculli -
**What I did**
- What I wanted to do was have a property that's based on teh license expiration that can be used to disable/enable things on the canvas. 
- We have one here,(https://github.com/Particular/ServiceMatrix/blob/release-2.0.0/src/ServiceMatrix.Automation/Model/Application.cs#L292)  but I wasn't sure how to get that in the Diagram's ViewModel.
- So, as a shortcut, i added a globalSettings class that I can bind to.

**Questions:**
1. Can we get rid of the GlobalSettings class and have the boolean currently being set in Application.cs to the view model? 
2. Any other suggestions?

**ToDo:** 
Let;s say, when I started VS, license has expired and I choose to open the solution anyway, the canvas is disabled. I close the solution and this time enter the license. But looks like I'll have to restart visual studio. Maybe I am missing something

cc/ @andreasohlund 
