### PR TITLE
Saga data class now derives from ContainSagaData instead of implementing IContainSagaData interface

### DIFF
--- a/src/ServiceMatrix.Automation/ValueProviders/ComponentMessageHandlers/ComponentHandlersCodeProvider.cs
+++ b/src/ServiceMatrix.Automation/ValueProviders/ComponentMessageHandlers/ComponentHandlersCodeProvider.cs
@@ -228,11 +228,8 @@ namespace NServiceBusStudio.Automation.ValueProviders.ComponentMessageHandlers
             {
                 sb.AppendLine("     }");
                 sb.AppendLine();
-                sb.AppendLine("     public partial class " + this.Component.CodeIdentifier + "SagaData : IContainSagaData");
+                sb.AppendLine("     public partial class " + this.Component.CodeIdentifier + "SagaData : ContainSagaData");
                 sb.AppendLine("     {");
-                sb.AppendLine("           public virtual Guid Id { get; set; }");
-                sb.AppendLine("           public virtual string Originator { get; set; }");
-                sb.AppendLine("           public virtual string OriginalMessageId { get; set; }");
                 sb.AppendLine();
 
                 foreach (var typename in this.TypeNames)


### PR DESCRIPTION
Fixes #243.

Tested with sagas created for both request / response and the event correlation saga by generating code for the following canvas:
![image](https://cloud.githubusercontent.com/assets/854553/2637537/7d0af3a6-be9e-11e3-88e6-4a119291f52c.png)
