### PR TITLE
Calling Processors, "Handlers" instead.

### DIFF
--- a/src/ServiceMatrix.Automation/Commands/CreateCommandComponents.cs
+++ b/src/ServiceMatrix.Automation/Commands/CreateCommandComponents.cs
@@ -10,7 +10,7 @@ using NuPattern.Diagnostics;
 namespace NServiceBusStudio.Automation.Commands
 {
     [DisplayName("Create Command's Components")]
-    [Description("Creates the Command's Sender component and Command's Processor component.")]
+    [Description("Creates the Command's Sender component and Command's handler component.")]
     [CLSCompliant(false)]
     public class CreateCommandComponents : NuPattern.Runtime.Command
     {
@@ -27,7 +27,7 @@ namespace NServiceBusStudio.Automation.Commands
                 CreateComponent(String.Format("{0}Sender", this.Command.InstanceName),
                             (c) => c.Publishes.CreateLink(this.Command));
             }
-            CreateComponent(String.Format("{0}Processor", this.Command.InstanceName),
+            CreateComponent(String.Format("{0}Handler", this.Command.InstanceName),
                             (c) => c.Subscribes.CreateLink(this.Command));
         }
 

--- a/src/ServiceMatrix.Automation/Commands/ShowSubscriberPicker.cs
+++ b/src/ServiceMatrix.Automation/Commands/ShowSubscriberPicker.cs
@@ -78,7 +78,7 @@ namespace NServiceBusStudio.Automation.Commands
                             selectedService = CurrentElement.Parent.Parent.Parent.Parent.CreateService(selectedElement);
                         }
 
-                        var component = selectedService.Components.CreateComponent(string.Format("{0}Processor", CurrentElement.InstanceName));
+                        var component = selectedService.Components.CreateComponent(string.Format("{0}Handler", CurrentElement.InstanceName));
                         component.Subscribes.CreateLink(CurrentElement);
                     }
                 }

--- a/src/ServiceMatrix.Automation/Commands/ShowUseCaseCommandPickerCommand.cs
+++ b/src/ServiceMatrix.Automation/Commands/ShowUseCaseCommandPickerCommand.cs
@@ -71,7 +71,7 @@ namespace NServiceBusStudio.Automation.Commands
                             cmd => cmd.DoNotAutogenerateComponents = true,
                             true);
 
-                        var processorName = Component.TryGetComponentName(command.InstanceName + "Processor", svc);
+                        var processorName = Component.TryGetComponentName(command.InstanceName + "Handler", svc);
                         var processorComponent = svc.Components.CreateComponent(processorName);
                         
                         processorComponent.Subscribe(command);

--- a/src/ServiceMatrix.Automation/Conditions/IsComponentCommandProcessorCondition.cs
+++ b/src/ServiceMatrix.Automation/Conditions/IsComponentCommandProcessorCondition.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace NServiceBusStudio.Automation.Conditions
 {
     [CLSCompliant(false)]
-    [DisplayName("Component Is Command Processor")]
+    [DisplayName("Component Is Command Handler")]
     [Category("General")]
     [Description("True if the component is processing a command.")]
     public class IsComponentCommandProcessorCondition : Condition

--- a/src/ServiceMatrix.Automation/Conditions/IsProcessorComponentCondition.cs
+++ b/src/ServiceMatrix.Automation/Conditions/IsProcessorComponentCondition.cs
@@ -12,7 +12,7 @@ using AbstractEndpoint;
 namespace NServiceBusStudio.Automation.Conditions
 {
     [CLSCompliant(false)]
-    [DisplayName("Component Is Defined as Command/Event Processor")]
+    [DisplayName("Component Is Defined as Command/Event Handler")]
     [Category("General")]
     [Description("True if the component is already defined as a processor.")]
     public class IsProcessorComponentCondition : Condition

--- a/src/ServiceMatrix.Automation/Model/Command.cs
+++ b/src/ServiceMatrix.Automation/Model/Command.cs
@@ -34,7 +34,7 @@ namespace NServiceBusStudio
                 if (result == MessageBoxResult.Yes)
                 {
                     DeleteComponent(String.Format("{0}Sender", this.InstanceName));
-                    DeleteComponent(String.Format("{0}Processor", this.InstanceName));
+                    DeleteComponent(String.Format("{0}Handler", this.InstanceName));
                 }
             };
         }


### PR DESCRIPTION
 Fixes #264 
The autogenerated code for the message handlers will be named [Message]Handler.cs instead of [Message]Processor.cs

![image](https://cloud.githubusercontent.com/assets/854553/2640426/bc69194a-bee6-11e3-8f3f-c0e7db7537ee.png)
