### PR TITLE
Close project property windows when unfolding t4 templates

### DIFF
--- a/src/ServiceMatrix.Automation/Commands/GenerateProductCodeCommandCustom.cs
+++ b/src/ServiceMatrix.Automation/Commands/GenerateProductCodeCommandCustom.cs
@@ -1,12 +1,13 @@
-﻿using NuPattern.Diagnostics;
-using NuPattern.Library.Commands;
-using ServiceMatrix.Diagramming.ViewModels;
-using System;
-using System.Collections.Generic;
+﻿using System;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell.Interop;
+using NuPattern.Diagnostics;
+using NuPattern.VisualStudio;
 
 namespace NuPattern.Library.Commands
 {
@@ -14,8 +15,25 @@ namespace NuPattern.Library.Commands
     {
         private static readonly ITracer tracer = Tracer.Get<GenerateProductCodeCommandCustom>();
 
+        private DTE dte;
+
+        [Browsable(false)]
+        internal DTE Dte
+        {
+            get
+            {
+                return dte ?? (dte = ServiceProvider.GetService<SDTE, DTE>());
+            }
+        }
+
+        [Required]
+        [Import(AllowDefault = true)]
+        public IUserMessageService UserMessageService { get; set; }
+
         public override void Execute()
         {
+            EnsureNoProjectDesignersAreOpen();
+
             try
             {
                 base.Execute();
@@ -23,6 +41,34 @@ namespace NuPattern.Library.Commands
             catch (IOException ex) 
             {
                 tracer.Error(ex, String.Format("The file {0} is locked by a process and cannot be regenerated. Please, close the locking process and try again.", this.TargetFileName));
+            }
+        }
+
+        void EnsureNoProjectDesignersAreOpen()
+        {
+            var notified = UserMessageService == null;
+
+            // TODO: Remove this function when NuPattern implements a workaround. 
+            // The workaround is to close all the project designers, which can cause exceptions in NuPattern's t4 unfold logic.
+            // Related NuPattern issue: https://github.com/NuPattern/NuPattern/issues/2
+            foreach (var window in Dte.Windows.OfType<Window>().Where(w => w.Type == vsWindowType.vsWindowTypeDocument))
+            {
+                try
+                {
+                    // just so this expression compiles
+                    var ignore = window.ProjectItem;
+                }
+                catch (InvalidCastException)
+                {
+                    if (!notified)
+                    {
+                        notified = true;
+
+                        UserMessageService.ShowInformation("ServiceMatrix has detected that some Project Designers are open. These designers will now be closed in order to proceed with code generation.");
+                    }
+
+                    window.Close();
+                }
             }
         }
     }


### PR DESCRIPTION
#378

Eagerly closes the project property pages which might cause a code generation exception. A single notification is shown if pages are to be closed.

This workaround will iterate over all open windows for each template that is unfold. It will no longer be needed once NuPattern can deal with this exception.

Related NuPattern Issue: https://github.com/NuPattern/NuPattern/issues/2
